### PR TITLE
Add mock data for genres to enhance development and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 ---
 
 > 🧪 **Heads up:** Game Hub is a **proof of concept (PoC)** built for learning and demonstration purposes. It is not production-grade software — expect rough edges, a hardcoded API key, and no automated tests.
+>
+> 🧩 **Mock data:** The **genres** and **parent platforms** lists are served from local mock files in [`src/data/`](src/data/) as React Query `initialData`. Live game results still come from the RAWG API.
 
 ---
 
@@ -31,6 +33,7 @@
 - 🌗 **Light / dark mode** toggle (persisted via `next-themes`)
 - 📱 **Fully responsive** layout (sidebar collapses below `lg` breakpoint)
 - ⚡ **24h client-side cache** via React Query — fewer requests, snappier UX
+- 🧩 **Mock/seed data** for genres and platforms in [`src/data/`](src/data/) — the sidebar renders instantly without waiting for RAWG
 
 ---
 
@@ -131,7 +134,7 @@ src/
   - Server state is *never* mirrored into Zustand.
 - **Generic API client** — every hook instantiates `new APIClient<Entity>(endpoint)` and wraps it in `useQuery` / `useInfiniteQuery`.
 - **24h `staleTime`** on the games list keeps navigation instant within a session.
-- **Static fallbacks** for genres and platforms in `src/data/` so the UI renders immediately.
+- **Static fallbacks (mock data)** for genres and platforms in [`src/data/genres.ts`](src/data/genres.ts) and [`src/data/platforms.ts`](src/data/platforms.ts) — used as React Query's `initialData` so the sidebar and platform selector render immediately, no spinner, no network round-trip.
 - **Route-level error boundary** — `GameDetailsPage` rethrows fetch errors, caught by `ErrorPage` via `errorElement`.
 
 Full arc42 documentation lives under [`docs/`](docs/):

--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -1,5 +1,5 @@
 export default {
-  count: 19,
+  count: 20,
   next: null,
   previous: null,
   results: [
@@ -874,6 +874,52 @@ export default {
           slug: "pirates-3",
           name: "Sid Meier's Pirates!",
           added: 2346,
+        },
+      ],
+    },
+    {
+      id: 99,
+      name: "Horror",
+      slug: "horror",
+      games_count: 12480,
+      image_background:
+        "https://media.rawg.io/media/games/cdd/cdd31b6b4b04ac39ee2bb4fb12c3aa3a.jpg",
+      games: [
+        {
+          id: 13668,
+          slug: "amnesia-the-dark-descent",
+          name: "Amnesia: The Dark Descent",
+          added: 10378,
+        },
+        {
+          id: 41,
+          slug: "little-nightmares",
+          name: "Little Nightmares",
+          added: 11493,
+        },
+        {
+          id: 9882,
+          slug: "dont-starve-together",
+          name: "Don't Starve Together",
+          added: 9877,
+        },
+        {
+          id: 4286,
+          slug: "bioshock",
+          name: "BioShock",
+          added: 11200,
+        },
+        {
+          id: 28,
+          slug: "red-dead-redemption-2",
+          name: "Outlast",
+          added: 7000,
+        },
+        {
+          id: 58616,
+          slug: "phasmophobia",
+          name: "Phasmophobia",
+          added: 4500,
         },
       ],
     },


### PR DESCRIPTION
This pull request updates the documentation and mock data for the Game Hub project, focusing on clarifying the use of local mock data for genres and platforms, and expanding the mock genres dataset.

**Documentation updates:**

* Updated the `README.md` to clarify that genres and parent platforms are served from local mock files in `src/data/` as React Query `initialData`, while live game results still come from the RAWG API.
* Added details in the `README.md` features and architecture sections to emphasize the use of static fallback/mock data for genres and platforms, specifying the relevant files and their usage for instant sidebar and platform selector rendering. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R137)

**Mock data enhancements:**

* Added a new "Horror" genre entry to the mock genres data in `src/data/genres.ts`, increasing the genre count from 19 to 20 and providing representative games for the new genre. [[1]](diffhunk://#diff-1ff43d42273014c9a09baebbf89d812d75235905ac7c145c304ac5deb60db82bL2-R2) [[2]](diffhunk://#diff-1ff43d42273014c9a09baebbf89d812d75235905ac7c145c304ac5deb60db82bR880-R925)