### PR TITLE
Add mock data for genres to enhance development and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 ---
 
 > 🧪 **Heads up:** Game Hub is a **proof of concept (PoC)** built for learning and demonstration purposes. It is not production-grade software — expect rough edges, a hardcoded API key, and no automated tests.
+>
+> 🧩 **Mock data:** The **genres** and **parent platforms** lists are served from local mock files in [`src/data/`](src/data/) as React Query `initialData`. Live game results still come from the RAWG API.
 
 ---
 
@@ -31,6 +33,7 @@
 - 🌗 **Light / dark mode** toggle (persisted via `next-themes`)
 - 📱 **Fully responsive** layout (sidebar collapses below `lg` breakpoint)
 - ⚡ **24h client-side cache** via React Query — fewer requests, snappier UX
+- 🧩 **Mock/seed data** for genres and platforms in [`src/data/`](src/data/) — the sidebar renders instantly without waiting for RAWG
 
 ---
 
@@ -131,7 +134,7 @@ src/
   - Server state is *never* mirrored into Zustand.
 - **Generic API client** — every hook instantiates `new APIClient<Entity>(endpoint)` and wraps it in `useQuery` / `useInfiniteQuery`.
 - **24h `staleTime`** on the games list keeps navigation instant within a session.
-- **Static fallbacks** for genres and platforms in `src/data/` so the UI renders immediately.
+- **Static fallbacks (mock data)** for genres and platforms in [`src/data/genres.ts`](src/data/genres.ts) and [`src/data/platforms.ts`](src/data/platforms.ts) — used as React Query's `initialData` so the sidebar and platform selector render immediately, no spinner, no network round-trip.
 - **Route-level error boundary** — `GameDetailsPage` rethrows fetch errors, caught by `ErrorPage` via `errorElement`.
 
 Full arc42 documentation lives under [`docs/`](docs/):

--- a/docs/arc42_05_building_blocks.md
+++ b/docs/arc42_05_building_blocks.md
@@ -50,7 +50,7 @@ Game Hub is a single React SPA. Internally it is organized into clearly separate
 | **Entities**        | TypeScript interfaces mirroring RAWG resources.                    | [src/entities/](../src/entities/) |
 | **Store**           | Zustand store holding the current `GameQuery` (genre, platform, sort, search). | [src/store.ts](../src/store.ts) |
 | **Theme**           | Chakra theme config + default color mode.                          | [src/theme.ts](../src/theme.ts) |
-| **Static data**     | Fallback lists for genres and platforms.                           | [src/data/](../src/data/)       |
+| **Static data**     | Seed/mock lists for genres and platforms; injected as React Query `initialData` so the sidebar renders instantly without a network round-trip. | [src/data/](../src/data/)       |
 
 ## Level 2: Key Building Blocks
 
@@ -79,9 +79,9 @@ Grouped by role:
 | ----------------- | -------------------------------------- | --------------------------------- |
 | `useGames`        | `useInfiniteQuery` + `APIClient.getAll` | `/games` (paginated)              |
 | `useGame`         | `useQuery` + `APIClient.get`           | `/games/:slug`                    |
-| `useGenres`       | `useQuery` (fallback to static data)   | `/genres`                         |
+| `useGenres`       | `useQuery` with `initialData` from [`src/data/genres.ts`](../src/data/genres.ts) | `/genres`          |
 | `useGenre`        | local lookup                           | —                                 |
-| `usePlatforms`    | `useQuery` (fallback to static data)   | `/platforms/lists/parents`        |
+| `usePlatforms`    | `useQuery` with `initialData` from [`src/data/platforms.ts`](../src/data/platforms.ts) | `/platforms/lists/parents` |
 | `usePlatform`     | local lookup                           | —                                 |
 | `useScreenshots`  | `useQuery`                             | `/games/:id/screenshots`          |
 | `useTrailers`     | `useQuery`                             | `/games/:id/movies`               |

--- a/docs/arc42_06_runtime.md
+++ b/docs/arc42_06_runtime.md
@@ -63,4 +63,5 @@ User      Router      GameDetailsPage     useGame        APIClient        RAWG A
 1. `index.html` loads `src/main.tsx`.
 2. `createRoot` mounts a tree of providers: `StrictMode` → Chakra `Provider` → `QueryClientProvider` → `RouterProvider`.
 3. `RouterProvider` resolves the current URL against `routes.tsx` and renders `Layout` + the matching child route.
-4. `ReactQueryDevtools` is mounted alongside in development.
+4. **Sidebar renders instantly** — `useGenres` and `usePlatforms` inject static seed data ([src/data/genres.ts](../src/data/genres.ts), [src/data/platforms.ts](../src/data/platforms.ts)) as React Query `initialData`. The genre and platform lists are available immediately on first paint, with no spinner and no RAWG round-trip. React Query refreshes them in the background after `staleTime` expires.
+5. `ReactQueryDevtools` is mounted alongside in development.

--- a/docs/arc42_08_concepts.md
+++ b/docs/arc42_08_concepts.md
@@ -55,7 +55,7 @@ Every hook follows the same shape:
 ## Caching & Performance
 
 - **`staleTime`** — `useGames` uses `24h`; reduces RAWG calls during normal browsing.
-- **Static fallbacks** — `useGenres` / `usePlatforms` ship with static seed data in [src/data/](../src/data/) so the UI renders instantly while the network call resolves.
+- **`initialData` for sidebar lists** — `useGenres` and `usePlatforms` pass static seed data ([src/data/genres.ts](../src/data/genres.ts), [src/data/platforms.ts](../src/data/platforms.ts)) as React Query's `initialData`. The genre and platform selectors render immediately on first paint with no spinner and no network dependency; React Query then refreshes in the background after `staleTime` expires.
 - **Code splitting** — Vite handles per-route bundles automatically via dynamic imports where used.
 - **Skeleton UI** — `GameCardSkeleton` renders during initial load to avoid layout shift.
 

--- a/docs/arc42_09_decisions.md
+++ b/docs/arc42_09_decisions.md
@@ -11,6 +11,7 @@ This section records the significant architectural decisions for Game Hub in lig
 | [GH] ADR005                            | Chakra UI v3 as component library      | Accepted |
 | [GH] ADR006                            | React Router 7 with data routes        | Accepted |
 | [GH] ADR007                            | Deploy as static SPA on Vercel         | Accepted |
+| [GH] ADR008                            | Use React Query `initialData` for static seed lists | Accepted |
 
 ---
 
@@ -104,3 +105,18 @@ This section records the significant architectural decisions for Game Hub in lig
 - ✅ Free / low-cost global CDN.
 - ✅ Zero-config deploy from GitHub `main`.
 - ⚠️ Any future server-side concerns (e.g. proxying the RAWG key) would require adding Vercel Functions or moving off-platform.
+
+## [GH] ADR008 - Use React Query `initialData` for static seed lists
+
+**Status**: Accepted
+
+**Context**: The genre and platform sidebar lists are fetched from the RAWG API (`/genres`, `/platforms/lists/parents`). On first paint these lists were blank for the duration of the network round-trip, causing a spinner and layout shift.
+
+**Decision**: Ship static seed lists in [src/data/genres.ts](../src/data/genres.ts) and [src/data/platforms.ts](../src/data/platforms.ts). Pass them as React Query's `initialData` in `useGenres` and `usePlatforms`. React Query treats the seed data as immediately available (no loading state) and refreshes from RAWG after `staleTime` expires.
+
+**Consequences**
+- ✅ Sidebar renders instantly on first paint — no spinner, no network round-trip required.
+- ✅ No extra state management; `initialData` is a first-class React Query concept.
+- ✅ Offline / slow-network resilience: the seed data always covers the common genres and platforms.
+- ⚠️ Seed files must be kept reasonably in sync with RAWG data; stale seeds are acceptable for display but could drift over time.
+- ⚠️ New genres/platforms added to RAWG will not appear until a live fetch completes (after `staleTime`).

--- a/internal-docs/docs-writer-flow.md
+++ b/internal-docs/docs-writer-flow.md
@@ -194,7 +194,7 @@ graph LR
         D9[arc42_09_decisions.md]
     end
 
-    WF -->|@copilot comment| AG
+    WF -->|"@copilot comment"| AG
     CI -->|always loaded| AG
     FI -->|loaded when editing| AG
     AG -->|reads before editing| T

--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -1,5 +1,5 @@
 export default {
-  count: 19,
+  count: 20,
   next: null,
   previous: null,
   results: [
@@ -874,6 +874,52 @@ export default {
           slug: "pirates-3",
           name: "Sid Meier's Pirates!",
           added: 2346,
+        },
+      ],
+    },
+    {
+      id: 99,
+      name: "Horror",
+      slug: "horror",
+      games_count: 12480,
+      image_background:
+        "https://media.rawg.io/media/games/cdd/cdd31b6b4b04ac39ee2bb4fb12c3aa3a.jpg",
+      games: [
+        {
+          id: 13668,
+          slug: "amnesia-the-dark-descent",
+          name: "Amnesia: The Dark Descent",
+          added: 10378,
+        },
+        {
+          id: 41,
+          slug: "little-nightmares",
+          name: "Little Nightmares",
+          added: 11493,
+        },
+        {
+          id: 9882,
+          slug: "dont-starve-together",
+          name: "Don't Starve Together",
+          added: 9877,
+        },
+        {
+          id: 4286,
+          slug: "bioshock",
+          name: "BioShock",
+          added: 11200,
+        },
+        {
+          id: 28,
+          slug: "red-dead-redemption-2",
+          name: "Outlast",
+          added: 7000,
+        },
+        {
+          id: 58616,
+          slug: "phasmophobia",
+          name: "Phasmophobia",
+          added: 4500,
         },
       ],
     },


### PR DESCRIPTION
This pull request updates the documentation and mock data for genres and platforms in the Game Hub project. The main focus is to clarify the use of local mock data for genres and platforms in the sidebar and to add a new "Horror" genre to the mock data.

**Documentation updates:**

* Clarified in `README.md` that genres and parent platforms are served from local mock files in `src/data/` as React Query `initialData`, and that live game results still come from the RAWG API.
* Updated feature list in `README.md` to highlight the use of mock/seed data for genres and platforms, improving sidebar rendering speed.
* Expanded technical details in `README.md` to specify that static fallbacks for genres and platforms are in `src/data/genres.ts` and `src/data/platforms.ts`, used as React Query's `initialData` for instant UI rendering.

**Mock data changes:**

* Added a new "Horror" genre to the `src/data/genres.ts` mock data, including its metadata and popular games.
* Updated the genre count in `src/data/genres.ts` from 19 to 20 to reflect the new genre.