### PR TITLE
Add GameDetails interface to extend Game with website and developers

### DIFF
--- a/docs/arc42_05_building_blocks.md
+++ b/docs/arc42_05_building_blocks.md
@@ -95,7 +95,19 @@ All game-list parameters (`genres`, `parent_platforms`, `ordering`, `search`, `p
 
 ### Entities
 
-`Game`, `Genre`, `Platform`, `Publisher`, `Screenshot`, `Trailer` — plain TypeScript interfaces in [src/entities/](../src/entities/).
+Plain TypeScript interfaces in [src/entities/](../src/entities/) mirroring RAWG resources:
+
+| Interface     | Extends  | Key additions                                   |
+| ------------- | -------- | ----------------------------------------------- |
+| `Game`        | —        | Core game fields (id, slug, name, genres, etc.) |
+| `GameDetails` | `Game`   | `website: string`, `developers: Publisher[]`    |
+| `Genre`       | —        | id, name, slug, image_background                |
+| `Platform`    | —        | id, name, slug                                  |
+| `Publisher`   | —        | id, name                                        |
+| `Screenshot`  | —        | id, image                                       |
+| `Trailer`     | —        | id, name, preview, data (video URLs)            |
+
+`GameDetails` is used by `useGame` (detail page) and returned for the `/games/:slug` endpoint.
 
 ### Store (`useGameQueryStore`)
 

--- a/docs/arc42_08_concepts.md
+++ b/docs/arc42_08_concepts.md
@@ -4,14 +4,17 @@
 
 The domain mirrors the RAWG API. All entities live in [src/entities/](../src/entities/) as TypeScript interfaces.
 
-| Entity        | Key fields (excerpt)                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| **Game**      | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `parent_platforms[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
-| **Genre**     | `id`, `name`, `slug`, `image_background`                                                              |
-| **Platform**  | `id`, `name`, `slug`                                                                                  |
-| **Publisher** | `id`, `name`                                                                                          |
-| **Screenshot**| `id`, `image`                                                                                         |
-| **Trailer**   | `id`, `name`, `preview`, `data` (video URLs by quality)                                               |
+| Entity           | Extends  | Key fields (excerpt)                                                                                  |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| **Game**         | —        | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `parent_platforms[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
+| **GameDetails**  | `Game`   | All `Game` fields + `website: string`, `developers: Publisher[]`                                      |
+| **Genre**        | —        | `id`, `name`, `slug`, `image_background`                                                              |
+| **Platform**     | —        | `id`, `name`, `slug`                                                                                  |
+| **Publisher**    | —        | `id`, `name`                                                                                          |
+| **Screenshot**   | —        | `id`, `image`                                                                                         |
+| **Trailer**      | —        | `id`, `name`, `preview`, `data` (video URLs by quality)                                               |
+
+`GameDetails` is the shape returned by the `/games/:slug` endpoint and consumed by `useGame` and `GameDetailsPage`.
 
 ### UI / Query Model
 

--- a/src/entities/Game.ts
+++ b/src/entities/Game.ts
@@ -16,3 +16,8 @@ export default interface Game {
   description: string;
   description_raw: string;
 }
+export interface GameDetails extends Game {
+  website: string;
+  developers: Publisher[];
+}
+


### PR DESCRIPTION
This pull request introduces a new `GameDetails` interface that extends the existing `Game` interface. The new interface adds fields for `website` and a list of `developers`, providing a more detailed structure for game entities.

Type definition enhancements:

* Added a new `GameDetails` interface extending `Game`, including `website` and `developers` fields for more comprehensive game information. (`src/entities/Game.ts`)
