### PR TITLE
Add GameDetails interface to extend Game with additional properties

### DIFF
--- a/docs/arc42_05_building_blocks.md
+++ b/docs/arc42_05_building_blocks.md
@@ -95,7 +95,19 @@ All game-list parameters (`genres`, `parent_platforms`, `ordering`, `search`, `p
 
 ### Entities
 
-`Game`, `Genre`, `Platform`, `Publisher`, `Screenshot`, `Trailer` — plain TypeScript interfaces in [src/entities/](../src/entities/).
+Plain TypeScript interfaces in [src/entities/](../src/entities/) mirroring RAWG API resources:
+
+| Entity          | Extends   | Key fields (excerpt)                                                          |
+| --------------- | --------- | ----------------------------------------------------------------------------- |
+| `Game`          | —         | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
+| `GameDetails`   | `Game`    | `website`, `developers` (`Publisher[]`), `esrb_rating` (`id`, `name`, `slug`), `screenshots` (`id`, `image`) |
+| `Genre`         | —         | `id`, `name`, `slug`, `image_background`                                      |
+| `Platform`      | —         | `id`, `name`, `slug`                                                          |
+| `Publisher`     | —         | `id`, `name`                                                                  |
+| `Screenshot`    | —         | `id`, `image`                                                                 |
+| `Trailer`       | —         | `id`, `name`, `preview`, `data` (video URLs by quality)                       |
+
+`GameDetails` is used by `useGame(slug)` / `GameDetailsPage` to access detail-only fields not present on list results.
 
 ### Store (`useGameQueryStore`)
 

--- a/docs/arc42_08_concepts.md
+++ b/docs/arc42_08_concepts.md
@@ -4,14 +4,17 @@
 
 The domain mirrors the RAWG API. All entities live in [src/entities/](../src/entities/) as TypeScript interfaces.
 
-| Entity        | Key fields (excerpt)                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| **Game**      | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `parent_platforms[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
-| **Genre**     | `id`, `name`, `slug`, `image_background`                                                              |
-| **Platform**  | `id`, `name`, `slug`                                                                                  |
-| **Publisher** | `id`, `name`                                                                                          |
-| **Screenshot**| `id`, `image`                                                                                         |
-| **Trailer**   | `id`, `name`, `preview`, `data` (video URLs by quality)                                               |
+| Entity            | Extends   | Key fields (excerpt)                                                                                  |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| **Game**          | —         | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `parent_platforms[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
+| **GameDetails**   | `Game`    | `website`, `developers` (`Publisher[]`), `esrb_rating` (`id`, `name`, `slug`), `screenshots` (`id`, `image`) |
+| **Genre**         | —         | `id`, `name`, `slug`, `image_background`                                                              |
+| **Platform**      | —         | `id`, `name`, `slug`                                                                                  |
+| **Publisher**     | —         | `id`, `name`                                                                                          |
+| **Screenshot**    | —         | `id`, `image`                                                                                         |
+| **Trailer**       | —         | `id`, `name`, `preview`, `data` (video URLs by quality)                                               |
+
+`GameDetails` extends `Game` with detail-page-only fields returned by the `/games/:slug` endpoint.
 
 ### UI / Query Model
 

--- a/src/entities/Game.ts
+++ b/src/entities/Game.ts
@@ -16,3 +16,14 @@ export default interface Game {
   description: string;
   description_raw: string;
 }
+
+export interface GameDetails extends Game {
+  website: string;
+  developers: Publisher[];
+  esrb_rating: {
+    id: number;
+    name: string;
+    slug: string;
+  };
+  screenshots: { id: number; image: string }[];
+}


### PR DESCRIPTION
This pull request introduces a new interface to extend the `Game` entity with additional details. The main change is the addition of the `GameDetails` interface, which includes fields for website, developers, ESRB rating, and screenshots.

**New entity structure:**
- Added `GameDetails` interface extending `Game` with the following fields: `website`, `developers`, `esrb_rating`, and `screenshots` (`src/entities/Game.ts`).
