### PR TITLE
Add GameDetails interface to extend Game with additional properties

### DIFF
--- a/docs/arc42_05_building_blocks.md
+++ b/docs/arc42_05_building_blocks.md
@@ -95,7 +95,17 @@ All game-list parameters (`genres`, `parent_platforms`, `ordering`, `search`, `p
 
 ### Entities
 
-`Game`, `Genre`, `Platform`, `Publisher`, `Screenshot`, `Trailer` — plain TypeScript interfaces in [src/entities/](../src/entities/).
+Plain TypeScript interfaces in [src/entities/](../src/entities/) that mirror RAWG API resources:
+
+| Entity          | Description                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `Game`          | Base game resource (list view): id, slug, name, image, genres, publishers, platforms, scores, descriptions. |
+| `GameDetails`   | Extends `Game` with detail-page fields: `website`, `developers` (`Publisher[]`), `esrb_rating`, `screenshots` (`{image}[]`). Used by `useGame` on the details page. |
+| `Genre`         | Genre resource.                                                                                  |
+| `Platform`      | Platform resource.                                                                               |
+| `Publisher`     | Publisher / developer resource (reused by `GameDetails.developers`).                             |
+| `Screenshot`    | Screenshot resource.                                                                             |
+| `Trailer`       | Trailer resource.                                                                                |
 
 ### Store (`useGameQueryStore`)
 

--- a/docs/arc42_08_concepts.md
+++ b/docs/arc42_08_concepts.md
@@ -4,14 +4,15 @@
 
 The domain mirrors the RAWG API. All entities live in [src/entities/](../src/entities/) as TypeScript interfaces.
 
-| Entity        | Key fields (excerpt)                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| **Game**      | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `parent_platforms[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
-| **Genre**     | `id`, `name`, `slug`, `image_background`                                                              |
-| **Platform**  | `id`, `name`, `slug`                                                                                  |
-| **Publisher** | `id`, `name`                                                                                          |
-| **Screenshot**| `id`, `image`                                                                                         |
-| **Trailer**   | `id`, `name`, `preview`, `data` (video URLs by quality)                                               |
+| Entity           | Key fields (excerpt)                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| **Game**         | `id`, `slug`, `name`, `background_image`, `genres[]`, `publishers[]`, `parent_platforms[]`, `metacritic`, `rating_top`, `released`, `description_raw` |
+| **GameDetails**  | Extends `Game` — adds `website`, `developers` (`Publisher[]`), `esrb_rating` (`{name}`), `screenshots` (`{image}[]`). Used exclusively on the game details page via `useGame`. |
+| **Genre**        | `id`, `name`, `slug`, `image_background`                                                              |
+| **Platform**     | `id`, `name`, `slug`                                                                                  |
+| **Publisher**    | `id`, `name` (also reused as developer shape in `GameDetails`)                                        |
+| **Screenshot**   | `id`, `image`                                                                                         |
+| **Trailer**      | `id`, `name`, `preview`, `data` (video URLs by quality)                                               |
 
 ### UI / Query Model
 

--- a/src/entities/Game.ts
+++ b/src/entities/Game.ts
@@ -16,3 +16,12 @@ export default interface Game {
   description: string;
   description_raw: string;
 }
+
+export default interface GameDetails extends Game {
+  website: string;
+  developers: Publisher[];
+  esrb_rating: {
+    name: string;
+  };
+  screenshots: { image: string }[];
+}


### PR DESCRIPTION
This pull request introduces a new interface, `GameDetails`, which extends the existing `Game` interface in `src/entities/Game.ts`. The new interface adds additional fields to represent more detailed information about a game.

New interface addition:

* Added `GameDetails` interface, extending `Game` with fields for `website`, `developers`, `esrb_rating`, and `screenshots` to support more comprehensive game data.